### PR TITLE
Add `NATPortsPerNetworkInterface` field to `Infrastructure`

### DIFF
--- a/pkg/apis/onmetal/types_infrastructure.go
+++ b/pkg/apis/onmetal/types_infrastructure.go
@@ -29,6 +29,9 @@ type InfrastructureConfig struct {
 
 	// NetworkRef references the network to use for the Shoot creation.
 	NetworkRef *corev1.LocalObjectReference
+	// NATPortsPerNetworkInterface defines the number of ports per network interface the NAT gateway should use.
+	// Has to be a power of 2. If empty, 2048 is the default.
+	NATPortsPerNetworkInterface *int32
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/onmetal/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/onmetal/v1alpha1/types_infrastructure.go
@@ -29,6 +29,9 @@ type InfrastructureConfig struct {
 
 	// NetworkRef references the network to use for the Shoot creation.
 	NetworkRef *corev1.LocalObjectReference `json:"networkRef,omitempty"`
+	// NATPortsPerNetworkInterface defines the number of ports per network interface the NAT gateway should use.
+	// Has to be a power of 2. If empty, 2048 is the default.
+	NATPortsPerNetworkInterface *int32 `json:"natPortsPerNetworkInterface,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/onmetal/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/onmetal/v1alpha1/zz_generated.conversion.go
@@ -215,6 +215,7 @@ func Convert_onmetal_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *onmet
 
 func autoConvert_v1alpha1_InfrastructureConfig_To_onmetal_InfrastructureConfig(in *InfrastructureConfig, out *onmetal.InfrastructureConfig, s conversion.Scope) error {
 	out.NetworkRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.NetworkRef))
+	out.NATPortsPerNetworkInterface = (*int32)(unsafe.Pointer(in.NATPortsPerNetworkInterface))
 	return nil
 }
 
@@ -225,6 +226,7 @@ func Convert_v1alpha1_InfrastructureConfig_To_onmetal_InfrastructureConfig(in *I
 
 func autoConvert_onmetal_InfrastructureConfig_To_v1alpha1_InfrastructureConfig(in *onmetal.InfrastructureConfig, out *InfrastructureConfig, s conversion.Scope) error {
 	out.NetworkRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.NetworkRef))
+	out.NATPortsPerNetworkInterface = (*int32)(unsafe.Pointer(in.NATPortsPerNetworkInterface))
 	return nil
 }
 

--- a/pkg/apis/onmetal/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/onmetal/v1alpha1/zz_generated.deepcopy.go
@@ -133,6 +133,11 @@ func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
+	if in.NATPortsPerNetworkInterface != nil {
+		in, out := &in.NATPortsPerNetworkInterface, &out.NATPortsPerNetworkInterface
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/onmetal/zz_generated.deepcopy.go
+++ b/pkg/apis/onmetal/zz_generated.deepcopy.go
@@ -133,6 +133,11 @@ func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
+	if in.NATPortsPerNetworkInterface != nil {
+		in, out := &in.NATPortsPerNetworkInterface, &out.NATPortsPerNetworkInterface
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -64,7 +64,7 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, infra *extens
 		return err
 	}
 
-	natGateway, err := a.applyNATGateway(ctx, onmetalClient, namespace, cluster, network)
+	natGateway, err := a.applyNATGateway(ctx, config, onmetalClient, namespace, cluster, network)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (a *actuator) applyPrefix(ctx context.Context, onmetalClient client.Client,
 	return prefix, nil
 }
 
-func (a *actuator) applyNATGateway(ctx context.Context, onmetalClient client.Client, namespace string, cluster *controller.Cluster, network *networkingv1alpha1.Network) (*networkingv1alpha1.NATGateway, error) {
+func (a *actuator) applyNATGateway(ctx context.Context, config *api.InfrastructureConfig, onmetalClient client.Client, namespace string, cluster *controller.Cluster, network *networkingv1alpha1.Network) (*networkingv1alpha1.NATGateway, error) {
 	natGateway := &networkingv1alpha1.NATGateway{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NATGateway",
@@ -130,6 +130,10 @@ func (a *actuator) applyNATGateway(ctx context.Context, onmetalClient client.Cli
 				Name: network.Name,
 			},
 		},
+	}
+
+	if ports := config.NATPortsPerNetworkInterface; ports != nil {
+		natGateway.Spec.PortsPerNetworkInterface = ports
 	}
 
 	natGateway.Spec.NetworkInterfaceSelector = &metav1.LabelSelector{

--- a/pkg/controller/infrastructure/actuator_reconcile_test.go
+++ b/pkg/controller/infrastructure/actuator_reconcile_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -72,6 +73,7 @@ var _ = Describe("Infrastructure Reconcile", func() {
 						NetworkRef: &corev1.LocalObjectReference{
 							Name: "my-network",
 						},
+						NATPortsPerNetworkInterface: pointer.Int32(1024),
 					}},
 				},
 				Region: "foo",
@@ -113,6 +115,7 @@ var _ = Describe("Infrastructure Reconcile", func() {
 					onmetal.ClusterNameLabel: cluster.ObjectMeta.Name,
 				},
 			}),
+			HaveField("Spec.PortsPerNetworkInterface", pointer.Int32(1024)),
 		))
 
 		By("expecting a prefix being created")


### PR DESCRIPTION
# Proposed Changes

Allow the configuration of the `portsPerNetworkInterfaces` of a `NATGateway` by introducing a new `NATPortsPerNetworkInterface` field to the `Infrastructure` configuration.
