### PR TITLE
Disable volume expansion in `StorageClasses` definition

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 parameters:
   type: {{ $value.type }}
-allowVolumeExpansion: true
+allowVolumeExpansion: false
 provisioner: csi.onmetal.de
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
# Proposed Changes

Disable volume expansion in `StorageClasses` definition as long as the `onmetal-csi-driver` does not support this feature by setting the following field on the `StorageClasses`:
```
allowVolumeExpansion: false
```