### PR TITLE
Add wait-for-csi-node annotation to csi-driver-node Pods

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
       role: disk-driver
   template:
     metadata:
+      annotations:
+        node.gardener.cloud/wait-for-csi-node-gcp: {{ include "csi-driver-node.provisioner" . }}
       labels:
         node.gardener.cloud/critical-component: "true"
         app: csi


### PR DESCRIPTION
# Proposed Changes

This PR adds the `wait-for-csi-node` annotation to `csi-driver-node` introduced in https://github.com/gardener/gardener/pull/7621