### PR TITLE
Fix `csi-driver-node` pod annotation

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        node.gardener.cloud/wait-for-csi-node-gcp: {{ include "csi-driver-node.provisioner" . }}
+        node.gardener.cloud/wait-for-csi-node-onmetal: {{ include "csi-driver-node.provisioner" . }}
       labels:
         node.gardener.cloud/critical-component: "true"
         app: csi


### PR DESCRIPTION
# Proposed changes 

Use the correct `onmetal` provider type annotation for the `csi-driver-node` pod.