### PR TITLE
chore: update cloud-controller-manager image tag to v0.1.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/onmetal/cloud-provider-onmetal
   repository: ghcr.io/onmetal/cloud-provider-onmetal
-  tag: "v0.1.2"
+  tag: "v0.1.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
# Proposed Changes

- Update the `cloud-controller-manager` image tag from `v0.1.2` to `v0.1.3`
