### PR TITLE
Refactor `GetOnmetalClientAndNamespaceFromCloudProviderSecret` to use `Shoot` namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ lint: ## Run golangci-lint on the code.
 	golangci-lint run ./...
 
 .PHONY: test
-test: generate fmt vet envtest ## Run tests.
+test: fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 	go mod tidy
 

--- a/hack/api-reference/template/tools.go
+++ b/hack/api-reference/template/tools.go
@@ -1,3 +1,17 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build tools
 // +build tools
 

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -34,7 +34,7 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 	log.V(2).Info("Deleting infrastructure")
 
 	// get onmetal credentials from infrastructure config
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), infra)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), cluster.ObjectMeta.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get onmetal client and namespace from cloudprovider secret: %w", err)
 	}

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -54,7 +54,7 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, infra *extens
 	}
 
 	// get onmetal credentials from infrastructure config
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), infra)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), cluster.ObjectMeta.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get onmetal client and namespace from cloudprovider secret: %w", err)
 	}

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -67,7 +67,7 @@ func (c *configValidator) Validate(ctx context.Context, infra *extensionsv1alpha
 	}
 
 	// get onmetal credentials from infrastructure config
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, c.client, infra)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, c.client, infra.Namespace)
 	if err != nil {
 		allErrs = append(allErrs, field.InternalError(nil, fmt.Errorf("could not get onmetal client and namespace: %w", err)))
 		return allErrs

--- a/pkg/onmetal/clientutils.go
+++ b/pkg/onmetal/clientutils.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
@@ -40,9 +39,11 @@ func init() {
 	utilruntime.Must(ipamv1alpha1.AddToScheme(onmetalScheme))
 }
 
-func GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx context.Context, cl client.Client, infra *extensionsv1alpha1.Infrastructure) (client.Client, string, error) {
+// GetOnmetalClientAndNamespaceFromCloudProviderSecret extracts the <onmetalClient, onmetalNamespace> from the
+// cloudprovider secret in the Shoot namespace.
+func GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx context.Context, cl client.Client, shootNamespace string) (client.Client, string, error) {
 	secret := &corev1.Secret{}
-	secretKey := client.ObjectKey{Namespace: infra.Namespace, Name: v1beta1constants.SecretNameCloudProvider}
+	secretKey := client.ObjectKey{Namespace: shootNamespace, Name: v1beta1constants.SecretNameCloudProvider}
 	if err := cl.Get(ctx, secretKey, secret); err != nil {
 		return nil, "", fmt.Errorf("failed to get cloudprovider secret: %w", err)
 	}


### PR DESCRIPTION
# Proposed Changes

Refactor `GetOnmetalClientAndNamespaceFromCloudProviderSecret` to use the `Shoot` namespace to extract the `onmetal` credentials from the `cloudprovider` secret.