### PR TITLE
Add support for internal load balancer configuration for CCM

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   cloudprovider.conf: |
     networkName: {{ .Values.networkName }}
+    prefixName: {{ .Values.prefixName }}

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -1,1 +1,2 @@
 networkName: foo
+prefixName: bar

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -42,9 +42,11 @@ apiVersion: onmetal.provider.extensions.gardener.cloud/v1alpha1
 kind: InfrastructureConfig
 networkRef:
   name: "my-network"
+prefixRef:
+  name: "my-prefix"
 ```
 
-Here the `networkRef` field references the network to use for the Shoot creation.
+Here the `networkRef` field refer to network and `prefixRef` field refer to prefix. Both are used for Shoot creation.
 
 ## `ControlPlaneConfig`
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -205,6 +205,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	// Collect config chart values
 	return map[string]interface{}{
 		onmetal.NetworkFieldName: infrastructureStatus.NetworkRef.Name,
+		onmetal.PrefixFieldName:  infrastructureStatus.PrefixRef.Name,
 	}, nil
 }
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -93,6 +93,10 @@ var _ = Describe("Valueprovider Reconcile", func() {
 								Name: "my-network",
 								UID:  "1234",
 							},
+							PrefixRef: v1alpha1.LocalUIDReference{
+								Name: "my-prefix",
+								UID:  "6789",
+							},
 						}),
 					},
 				},
@@ -111,6 +115,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 			cloudProviderConfig := map[string]interface{}{}
 			Expect(yaml.Unmarshal([]byte(config.Data["cloudprovider.conf"]), &cloudProviderConfig)).NotTo(HaveOccurred())
 			Expect(cloudProviderConfig["networkName"]).To(Equal("my-network"))
+			Expect(cloudProviderConfig["prefixName"]).To(Equal("my-prefix"))
 		})
 	})
 


### PR DESCRIPTION
# Proposed Changes

- Extend the `cloud-provider-config` chart
- Update the Cloud Controller Manager configuration process.
- Write unit tests 
- Update docs.

Fixes https://github.com/onmetal/gardener-extension-provider-onmetal/issues/183