### PR TITLE
Update `onmetal-api` version in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/onmetal/controller-utils v0.7.0
-	github.com/onmetal/onmetal-api v0.1.1
+	github.com/onmetal/onmetal-api v0.1.2-0.20230425083928-00b302f8455b
 	github.com/onsi/ginkgo/v2 v2.9.7
 	github.com/onsi/gomega v1.27.7
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onmetal/controller-utils v0.7.0 h1:EHLPb/XimNas1VkeZZLP4g31aSz+ipiwvwWhklaQob0=
 github.com/onmetal/controller-utils v0.7.0/go.mod h1:91KV/s0VaB8PC+hqsxo6OBsAhi3ICFgIFLv/36V0ng8=
-github.com/onmetal/onmetal-api v0.1.1 h1:8YEtQBsxQzb+MKvbFypuYp/x8AZ96mN4NCx8bRxHvFA=
-github.com/onmetal/onmetal-api v0.1.1/go.mod h1:mql3gEgyCDeqkQbeM62C/FRuCwXSfBVsvg/FiBczN6M=
+github.com/onmetal/onmetal-api v0.1.2-0.20230425083928-00b302f8455b h1:wvzwi78lCAsiyDofFRQSCnB/t6Uyt05uoAvgqh//gPE=
+github.com/onmetal/onmetal-api v0.1.2-0.20230425083928-00b302f8455b/go.mod h1:plZ0WIlHY5ZnTaVFJLsbn4X9pFUXIqiR4gYbWEaC0vg=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
# Proposed Changes

- Update version of github.com/onmetal/onmetal-api from v0.1.1 to v0.1.2-0.20230425083928-00b302f8455b in go.mod file