### PR TITLE
Refactor test setup and use `SpecContext` 

### DIFF
--- a/pkg/controller/bastion/actuator_delete_test.go
+++ b/pkg/controller/bastion/actuator_delete_test.go
@@ -31,15 +31,12 @@ import (
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 )
 
 var _ = Describe("Bastion Host Delete", func() {
-	ctx := testutils.SetupContext()
-	ns := SetupTest(ctx)
+	ns := SetupTest()
 
-	It("should ensure that the bastion is deleted along with bastion host and ignition secret", func() {
-
+	It("should ensure that the bastion is deleted along with bastion host and ignition secret", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/bastion/actuator_reconcile_test.go
+++ b/pkg/controller/bastion/actuator_reconcile_test.go
@@ -33,15 +33,12 @@ import (
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 )
 
 var _ = Describe("Bastion Host Reconcile", func() {
-	ctx := testutils.SetupContext()
-	ns := SetupTest(ctx)
+	ns := SetupTest()
 
-	It("should create igntion secret and machine for a given bastion configuration", func() {
-
+	It("should create igntion secret and machine for a given bastion configuration", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -66,7 +63,7 @@ var _ = Describe("Bastion Host Reconcile", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, bastion)).Should(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, bastion)
+		DeferCleanup(k8sClient.Delete, bastion)
 
 		Eventually(Object(bastion)).Should(SatisfyAll(
 			HaveField("Status.LastOperation.Type", gardencorev1beta1.LastOperationTypeCreate),
@@ -122,7 +119,7 @@ var _ = Describe("Bastion Host Reconcile", func() {
 			VirtualIP: &commonv1alpha1.IP{Addr: netip.MustParseAddr("10.0.0.10")},
 		}}
 		Expect(k8sClient.Status().Patch(ctx, bastionHost, client.MergeFrom(machineBase))).To(Succeed())
-		DeferCleanup(k8sClient.Delete, ctx, bastionHost)
+		DeferCleanup(k8sClient.Delete, bastionHost)
 
 		By("ensuring that bastion host is created and Running")
 		Eventually(Object(bastionHost)).Should(SatisfyAll(

--- a/pkg/controller/bastion/configvalidator_test.go
+++ b/pkg/controller/bastion/configvalidator_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gstruct "github.com/onsi/gomega/gstruct"
@@ -31,8 +30,7 @@ import (
 )
 
 var _ = Describe("ConfigValidator", func() {
-	ctx := testutils.SetupContext()
-	ns := SetupTest(ctx)
+	ns := SetupTest()
 
 	var (
 		configValidator bastion.ConfigValidator
@@ -44,14 +42,14 @@ var _ = Describe("ConfigValidator", func() {
 		configValidator = NewConfigValidator(k8sClient, logger)
 	})
 
-	It("should return error for an empty bastion config", func() {
+	It("should return error for an empty bastion config", func(ctx SpecContext) {
 		errorList := configValidator.Validate(ctx, nil, cluster)
 		Expect(errorList).To(ConsistOfFields(gstruct.Fields{
 			"Detail": Equal("bastion can not be nil"),
 		}))
 	})
 
-	It("should return error for an empty bastion userdata", func() {
+	It("should return error for an empty bastion userdata", func(ctx SpecContext) {
 		bastion := &gardenerextensionv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
@@ -67,7 +65,7 @@ var _ = Describe("ConfigValidator", func() {
 		}))
 	})
 
-	It("should return error for an empty bastion CIDR", func() {
+	It("should return error for an empty bastion CIDR", func(ctx SpecContext) {
 		bastion := &gardenerextensionv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
@@ -88,7 +86,7 @@ var _ = Describe("ConfigValidator", func() {
 		}))
 	})
 
-	It("should return error for an invalid bastion spec CIDR", func() {
+	It("should return error for an invalid bastion spec CIDR", func(ctx SpecContext) {
 		bastion := &gardenerextensionv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
@@ -113,7 +111,7 @@ var _ = Describe("ConfigValidator", func() {
 		}))
 	})
 
-	It("should return error for an empty cluster", func() {
+	It("should return error for an empty cluster", func(ctx SpecContext) {
 		bastion := &gardenerextensionv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
@@ -137,7 +135,8 @@ var _ = Describe("ConfigValidator", func() {
 			"Detail": Equal("cluster can not be nil"),
 		}))
 	})
-	It("should return error for an empty cluster shoot", func() {
+
+	It("should return error for an empty cluster shoot", func(ctx SpecContext) {
 		bastion := &gardenerextensionv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -42,19 +42,17 @@ import (
 	"github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
 	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 )
 
 var _ = Describe("Valueprovider Reconcile", func() {
-	ctx := testutils.SetupContext()
-	ns, vp := SetupTest(ctx)
+	ns, vp := SetupTest()
 
 	var (
 		fakeClient         client.Client
 		fakeSecretsManager secretsmanager.Interface
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		curDir, err := os.Getwd()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Chdir(filepath.Join("..", "..", ".."))).To(Succeed())
@@ -66,7 +64,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 	})
 
 	Describe("#GetConfigChartValues", func() {
-		It("should return correct config chart values", func() {
+		It("should return correct config chart values", func(ctx SpecContext) {
 			cp := &extensionsv1alpha1.ControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "control-plane",
@@ -123,7 +121,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 	})
 
 	Describe("#GetStorageClassesChartValues", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("creating an expand only VolumeClass")
 			volumeClassExpandOnly := &storagev1alpha1.VolumeClass{
 				ObjectMeta: metav1.ObjectMeta{
@@ -136,7 +134,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 				ResizePolicy: storagev1alpha1.ResizePolicyExpandOnly,
 			}
 			Expect(k8sClient.Create(ctx, volumeClassExpandOnly)).To(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, volumeClassExpandOnly)
+			DeferCleanup(k8sClient.Delete, volumeClassExpandOnly)
 
 			By("creating an static VolumeClass")
 			volumeClassStatic := &storagev1alpha1.VolumeClass{
@@ -150,9 +148,9 @@ var _ = Describe("Valueprovider Reconcile", func() {
 				ResizePolicy: storagev1alpha1.ResizePolicyStatic,
 			}
 			Expect(k8sClient.Create(ctx, volumeClassStatic)).To(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, volumeClassStatic)
+			DeferCleanup(k8sClient.Delete, volumeClassStatic)
 		})
-		It("should return an empty config chart value map if not storageclasses are present in the cloudprofile", func() {
+		It("should return an empty config chart value map if not storageclasses are present in the cloudprofile", func(ctx SpecContext) {
 			providerCloudProfile := &apisonmetal.CloudProfileConfig{}
 			providerCloudProfileJson, err := json.Marshal(providerCloudProfile)
 			Expect(err).NotTo(HaveOccurred())
@@ -177,7 +175,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 			}))
 		})
 
-		It("should return correct config chart values if default and additional storage classes are present in the cloudprofile", func() {
+		It("should return correct config chart values if default and additional storage classes are present in the cloudprofile", func(ctx SpecContext) {
 			providerCloudProfile := &apisonmetal.CloudProfileConfig{
 				StorageClasses: apisonmetal.StorageClasses{
 					Default: &apisonmetal.StorageClass{
@@ -236,7 +234,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 			}))
 		})
 
-		It("should return correct config chart values if only additional storage classes are present in the cloudprofile", func() {
+		It("should return correct config chart values if only additional storage classes are present in the cloudprofile", func(ctx SpecContext) {
 			providerCloudProfile := &apisonmetal.CloudProfileConfig{
 				StorageClasses: apisonmetal.StorageClasses{
 					Additional: []apisonmetal.StorageClass{
@@ -285,7 +283,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 			}))
 		})
 
-		It("should return error if volumeClass is not available", func() {
+		It("should return error if volumeClass is not available", func(ctx SpecContext) {
 			providerCloudProfile := &apisonmetal.CloudProfileConfig{
 				StorageClasses: apisonmetal.StorageClasses{
 					Default: &apisonmetal.StorageClass{
@@ -317,7 +315,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 	})
 
 	Describe("#GetControlPlaneShootCRDsChartValues", func() {
-		It("should return correct config chart values", func() {
+		It("should return correct config chart values", func(ctx SpecContext) {
 			values, err := vp.GetControlPlaneShootCRDsChartValues(ctx, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{}))
@@ -325,7 +323,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 	})
 
 	Describe("#GetControlPlaneShootChartValues", func() {
-		It("should return correct config chart values", func() {
+		It("should return correct config chart values", func(ctx SpecContext) {
 			providerCloudProfile := &apisonmetal.CloudProfileConfig{
 				StorageClasses: apisonmetal.StorageClasses{
 					Default: &apisonmetal.StorageClass{
@@ -381,7 +379,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 	})
 
 	Describe("#GetControlPlaneChartValues", func() {
-		It("should return correct config chart values", func() {
+		It("should return correct config chart values", func(ctx SpecContext) {
 			cp := &extensionsv1alpha1.ControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "control-plane",

--- a/pkg/controller/infrastructure/actuator_delete_test.go
+++ b/pkg/controller/infrastructure/actuator_delete_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,10 +32,9 @@ import (
 )
 
 var _ = Describe("Infrastructure Reconcile", func() {
-	ctx := testutils.SetupContext()
-	ns := SetupTest(ctx)
+	ns := SetupTest()
 
-	It("should ensure that the network, natgateway and prefix is being deleted", func() {
+	It("should ensure that the network, natgateway and prefix is being deleted", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/infrastructure/actuator_reconcile_test.go
+++ b/pkg/controller/infrastructure/actuator_reconcile_test.go
@@ -25,7 +25,6 @@ import (
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -36,10 +35,9 @@ import (
 )
 
 var _ = Describe("Infrastructure Reconcile", func() {
-	ctx := testutils.SetupContext()
-	ns := SetupTest(ctx)
+	ns := SetupTest()
 
-	It("should create a network, natgateway and prefix for a given infrastructure configuration", func() {
+	It("should create a network, natgateway and prefix for a given infrastructure configuration", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -152,7 +150,7 @@ var _ = Describe("Infrastructure Reconcile", func() {
 		))
 	})
 
-	It("should create a network, natgateway and prefix for a given infrastructure configuration", func() {
+	It("should create a network, natgateway and prefix for a given infrastructure configuration", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -33,8 +32,7 @@ import (
 )
 
 var _ = Describe("ConfigValidator", func() {
-	ctx := testutils.SetupContext()
-	ns := SetupTest(ctx)
+	ns := SetupTest()
 
 	var (
 		configValidator infrastructure.ConfigValidator
@@ -45,7 +43,7 @@ var _ = Describe("ConfigValidator", func() {
 		configValidator = NewConfigValidator(k8sClient, logger)
 	})
 
-	It("should pass on an empty infrastructure config", func() {
+	It("should pass on an empty infrastructure config", func(ctx SpecContext) {
 		infra := &gardenerextensionv1alpha1.Infrastructure{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
@@ -59,7 +57,7 @@ var _ = Describe("ConfigValidator", func() {
 		Expect(errorList).To(BeEmpty())
 	})
 
-	It("should pass if the referenced network exists", func() {
+	It("should pass if the referenced network exists", func(ctx SpecContext) {
 		network := &networkingv1alpha1.Network{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
@@ -96,7 +94,7 @@ var _ = Describe("ConfigValidator", func() {
 		}))
 	})
 
-	It("should not pass if the referenced network does not exists", func() {
+	It("should not pass if the referenced network does not exists", func(ctx SpecContext) {
 		infra := &gardenerextensionv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,

--- a/pkg/controller/worker/machine_images_test.go
+++ b/pkg/controller/worker/machine_images_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	apiv1alpha1 "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,10 +29,9 @@ import (
 )
 
 var _ = Describe("MachinesImages", func() {
-	ctx := testutils.SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 
-	It("should update the worker status", func() {
+	It("should update the worker status", func(ctx SpecContext) {
 		By("defining and setting infrastructure status for worker")
 		infraStatus := &apiv1alpha1.InfrastructureStatus{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -26,7 +26,6 @@ import (
 	onmetalextensionv1alpha1 "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -37,8 +36,7 @@ import (
 )
 
 var _ = Describe("Machines", func() {
-	ctx := testutils.SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 
 	It("should create the correct kind of the machine class", func() {
 		workerDelegate, err := NewWorkerDelegate(common.NewClientContext(nil, nil, nil), "", nil, nil)
@@ -58,7 +56,7 @@ var _ = Describe("Machines", func() {
 		Expect(workerDelegate.MachineClassList()).To(Equal(&machinecontrollerv1alpha1.MachineClassList{}))
 	})
 
-	It("should create the expected machine class for a multi zone cluster", func() {
+	It("should create the expected machine class for a multi zone cluster", func(ctx SpecContext) {
 		By("defining and setting infrastructure status for worker")
 		infraStatus := &onmetalextensionv1alpha1.InfrastructureStatus{
 			TypeMeta: metav1.TypeMeta{
@@ -149,7 +147,7 @@ var _ = Describe("Machines", func() {
 		))
 	})
 
-	It("should generate the machine deployments", func() {
+	It("should generate the machine deployments", func(ctx SpecContext) {
 		By("creating a worker delegate")
 		workerPoolHash, err := worker.WorkerPoolHash(pool, cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/worker/suite_test.go
+++ b/pkg/controller/worker/suite_test.go
@@ -15,7 +15,6 @@
 package worker
 
 import (
-	"context"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -132,13 +131,13 @@ var _ = BeforeSuite(func() {
 	komega.SetClient(k8sClient)
 })
 
-func SetupTest(ctx context.Context) (*corev1.Namespace, *gardener.ChartApplier) {
+func SetupTest() (*corev1.Namespace, *gardener.ChartApplier) {
 	var (
 		chartApplier gardener.ChartApplier
 	)
 	ns := &corev1.Namespace{}
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		var err error
 		*ns = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -146,6 +145,7 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *gardener.ChartApplier) 
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed(), "failed to create test namespace")
+		DeferCleanup(k8sClient.Delete, ns)
 
 		chartApplier, err = gardener.NewChartApplierForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
@@ -241,10 +241,6 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *gardener.ChartApplier) 
 				},
 			},
 		}
-	})
-
-	AfterEach(func() {
-		Expect(k8sClient.Delete(ctx, ns)).To(Succeed(), "failed to delete test namespace")
 	})
 
 	return ns, &chartApplier


### PR DESCRIPTION
# Proposed Changes

- Remove dependency on `testutils` package
- Remove unused import of `context` in `suite_test.go`
- Change `SetupTest` function signature to take no arguments in all relevant files
- Change `ctx` argument to `SpecContext` in `It` function calls
- Remove unnecessary cancellation of context and use `DeferCleanup` instead
- Add `DeferCleanup` calls for created objects to ensure cleanup after tests
