### PR TITLE
Do not base64 encode the `UserData` for `Bastion` host

### DIFF
--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -180,7 +180,7 @@ func generateIgnitionSecret(namespace string, opt *Options) (*corev1.Secret, err
 	// Construct ignition file config
 	config := &ignition.Config{
 		Hostname:   opt.BastionInstanceName,
-		UserData:   opt.UserData,
+		UserData:   string(opt.UserData),
 		DnsServers: []netip.Addr{netip.MustParseAddr("8.8.8.8")},
 	}
 

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -15,8 +15,6 @@
 package bastion
 
 import (
-	"encoding/base64"
-
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
@@ -27,7 +25,7 @@ import (
 // resources, like the nic name, subnet name etc.
 type Options struct {
 	BastionInstanceName string
-	UserData            string
+	UserData            []byte
 	//TODO: add networkPolicy
 }
 
@@ -41,6 +39,6 @@ func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.C
 	}
 	return &Options{
 		BastionInstanceName: baseResourceName,
-		UserData:            base64.StdEncoding.EncodeToString(bastion.Spec.UserData),
+		UserData:            bastion.Spec.UserData,
 	}, nil
 }


### PR DESCRIPTION
# Proposed Changes

- Change the `UserData` field in `pkg/controller/bastion/options.go` from a string to a byte array
- Change the `UserData` field in `pkg/controller/bastion/actuator_reconcile.go` from a string to a string representation of a byte array