### PR TITLE
Inject Cluster Name into ConfigMap in cloud-provider-config Helm Chart

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -7,3 +7,4 @@ data:
   cloudprovider.conf: |
     networkName: {{ .Values.networkName }}
     prefixName: {{ .Values.prefixName }}
+    clusterName: {{ .Values.clusterName }}

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -1,2 +1,3 @@
 networkName: foo
 prefixName: bar
+clusterName: test

--- a/pkg/controller/controlplane/suite_test.go
+++ b/pkg/controller/controlplane/suite_test.go
@@ -23,11 +23,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/onmetal/controller-utils/buildutils"
-	"github.com/onmetal/controller-utils/modutils"
-	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
-	utilsenvtest "github.com/onmetal/onmetal-api/utils/envtest"
-	"github.com/onmetal/onmetal-api/utils/envtest/apiserver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +37,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/onmetal/controller-utils/buildutils"
+	"github.com/onmetal/controller-utils/modutils"
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	utilsenvtest "github.com/onmetal/onmetal-api/utils/envtest"
+	"github.com/onmetal/onmetal-api/utils/envtest/apiserver"
 
 	onmetalextensionv1alpha1 "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
 )
@@ -127,7 +128,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
-func SetupTest() (*corev1.Namespace, *valuesProvider) {
+func SetupTest() (*corev1.Namespace, *valuesProvider, *extensionsv1alpha1.Cluster) {
 	var (
 		namespace = &corev1.Namespace{}
 		cluster   = &extensionsv1alpha1.Cluster{}
@@ -241,5 +242,5 @@ func SetupTest() (*corev1.Namespace, *valuesProvider) {
 		}()
 	})
 
-	return namespace, vp
+	return namespace, vp, cluster
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -33,7 +33,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -46,6 +45,7 @@ import (
 	apisonmetal "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/internal"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 )
 
 const (
@@ -214,6 +214,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	return map[string]interface{}{
 		onmetal.NetworkFieldName: infrastructureStatus.NetworkRef.Name,
 		onmetal.PrefixFieldName:  infrastructureStatus.PrefixRef.Name,
+		onmetal.ClusterFieldName: cluster.ObjectMeta.Name,
 	}, nil
 }
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -23,9 +23,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
-	"github.com/onmetal/onmetal-api/api/common/v1alpha1"
-	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
-	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -42,10 +39,13 @@ import (
 	apisonmetal "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/internal"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
+	"github.com/onmetal/onmetal-api/api/common/v1alpha1"
+	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 )
 
 var _ = Describe("Valueprovider Reconcile", func() {
-	ns, vp := SetupTest()
+	ns, vp, cluster := SetupTest()
 
 	var (
 		fakeClient         client.Client
@@ -117,6 +117,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 			Expect(yaml.Unmarshal([]byte(config.Data["cloudprovider.conf"]), &cloudProviderConfig)).NotTo(HaveOccurred())
 			Expect(cloudProviderConfig["networkName"]).To(Equal("my-network"))
 			Expect(cloudProviderConfig["prefixName"]).To(Equal("my-prefix"))
+			Expect(cloudProviderConfig["clusterName"]).To(Equal(cluster.Name))
 		})
 	})
 

--- a/pkg/onmetal/types.go
+++ b/pkg/onmetal/types.go
@@ -55,6 +55,8 @@ const (
 	NetworkFieldName = "networkName"
 	// PrefixFieldName is the name of the prefix field
 	PrefixFieldName = "prefixName"
+	// ClusterFieldName is the name of the cluster field
+	ClusterFieldName = "clusterName"
 	// LabelsFieldName is the name of the labels field
 	LabelsFieldName = "labels"
 	// UserDataFieldName is the name of the user data field


### PR DESCRIPTION
# Proposed Changes

- Update the controlplane controller to inject the clusterName into the chart deployment
- Test the implementation to ensure that the cluster name is correctly injected into the ConfigMap

Fixes #231 