### PR TITLE
Add `configure-cloud-routes` flag and related values and functions

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -45,6 +45,7 @@ spec:
             - --cluster-cidr={{ .Values.podNetwork }}
             - --cluster-name={{ .Values.clusterName }}
             - --concurrent-service-syncs=10
+            - --configure-cloud-routes={{ .Values.configureCloudRoutes }}
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
             - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
             - --authentication-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -10,7 +10,7 @@ images:
   cloud-controller-manager: image-repository:image-tag
 resources:
   requests:
-    cpu: 100m 
+    cpu: 100m
     memory: 75Mi
   limits:
     memory: 400Mi
@@ -22,3 +22,5 @@ vpa:
     maxAllowed:
       cpu: 4
       memory: 10G
+
+configureCloudRoutes: false


### PR DESCRIPTION
# Proposed Changes

- Add `--configure-cloud-routes` flag to the `cloud-controller-manager.yaml` file
- Set `configureCloudRoutes` value to `false` in the `values.yaml` file
- Add `isOverlayEnabled` function to the `valuesprovider.go` file
- Add `networkProviderConfig` and `networkProviderConfigData` variables to the `valuesprovider_test.go` file