### PR TITLE
Fix wrong cluster networking overlay detection 

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -405,11 +405,11 @@ func getCCMChartValues(
 		values["featureGates"] = cpConfig.CloudControllerManager.FeatureGates
 	}
 
-	configureCloudRoutes, err := isOverlayEnabled(cluster.Shoot.Spec.Networking)
+	overlayEnabled, err := isOverlayEnabled(cluster.Shoot.Spec.Networking)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine if overlay is enabled: %w", err)
 	}
-	values["configureCloudRoutes"] = configureCloudRoutes
+	values["configureCloudRoutes"] = !overlayEnabled
 
 	return values, nil
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -436,7 +436,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 				"kind":       "FooNetworkConfig",
 				"apiVersion": "v1alpha1",
 				"overlay": map[string]any{
-					"enabled": true,
+					"enabled": false,
 				},
 			}}
 			networkProviderConfigData, err := runtime.Encode(unstructured.UnstructuredJSONScheme, networkProviderConfig)


### PR DESCRIPTION
# Proposed Changes

- Change the variable name `configureCloudRoutes` to `overlayEnabled` in `valuesprovider.go`
- Invert the value of `configureCloudRoutes` in `valuesprovider.go`
- Change the value of `enabled` from `true` to `false` in `valuesprovider_test.go`