### PR TITLE
Bump `gardener` to `v1.75.x`

### DIFF
--- a/cmd/gardener-extension-provider-onmetal/app/app.go
+++ b/cmd/gardener-extension-provider-onmetal/app/app.go
@@ -30,14 +30,6 @@ import (
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/component-base/version/verflag"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	onmetalinstall "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/install"
 	onmetalcmd "github.com/onmetal/gardener-extension-provider-onmetal/pkg/cmd"
 	backupbucketcontroller "github.com/onmetal/gardener-extension-provider-onmetal/pkg/controller/backupbucket"
@@ -49,6 +41,13 @@ import (
 	workercontroller "github.com/onmetal/gardener-extension-provider-onmetal/pkg/controller/worker"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	controlplanewebhook "github.com/onmetal/gardener-extension-provider-onmetal/pkg/webhook/controlplane"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/component-base/version/verflag"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // NewControllerManagerCommand creates a new command for running a onmetal provider controller.
@@ -223,7 +222,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 			onmetalcontrolplane.DefaultAddOptions.WebhookServerNamespace = webhookOptions.Server.Namespace
 
-			if err := controllerSwitches.Completed().AddToManager(mgr); err != nil {
+			if err := controllerSwitches.Completed().AddToManager(ctx, mgr); err != nil {
 				return fmt.Errorf("could not add controllers to manager: %w", err)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coreos/butane v0.18.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/gardener/etcd-druid/api v0.6.0
-	github.com/gardener/gardener v1.73.1
+	github.com/gardener/gardener v1.75.1
 	github.com/gardener/machine-controller-manager v0.49.3
 	github.com/go-logr/logr v1.2.4
 	github.com/golang/mock v1.6.0
@@ -115,7 +115,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	istio.io/api v0.0.0-20230217221049-9d422bf48675 // indirect
 	istio.io/client-go v1.17.1 // indirect
-	k8s.io/apiserver v0.26.3 // indirect
 	k8s.io/helm v2.16.1+incompatible // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-aggregator v0.26.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/etcd-druid/api v0.6.0 h1:XVrH3i2Phxf5wPnqI/9UL5I7Rb4kC+XYqquEzdtRxKI=
 github.com/gardener/etcd-druid/api v0.6.0/go.mod h1:vaVjHhgtJ22MhGxedLJ175gTfSG4l7xnAtlR6P9wRic=
-github.com/gardener/gardener v1.73.1 h1:TqFEKTtz7m+6pcOS0rm7sOysOfEsVv8JdWw0/12fKQo=
-github.com/gardener/gardener v1.73.1/go.mod h1:uSkzPPoAEvdU1fvciTAsZFxPQ9vQpMbMFRJLMQgdfEQ=
+github.com/gardener/gardener v1.75.1 h1:swf09N6L/7PtJ9psISgzoG3A7+IGcS0jwlUaFvjfK8g=
+github.com/gardener/gardener v1.75.1/go.mod h1:vABeQSerLzU1NHbcvR3OafPdfwnnjg2VrX3ZIRhk9t4=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.49.3 h1:/ghxZVMij00SpeaORMZJlodosePWWByrIOr8fcp45sU=
@@ -872,7 +872,6 @@ k8s.io/apimachinery v0.19.6/go.mod h1:6sRbGRAVY5DOCuZwB5XkqguBqpqLU6q/kOaOdk29z6
 k8s.io/apimachinery v0.26.3 h1:dQx6PNETJ7nODU3XPtrwkfuubs6w7sX0M8n61zHIV/k=
 k8s.io/apimachinery v0.26.3/go.mod h1:ats7nN1LExKHvJ9TmwootT00Yz05MuYqPXEXaVeOy5I=
 k8s.io/apiserver v0.26.3 h1:blBpv+yOiozkPH2aqClhJmJY+rp53Tgfac4SKPDJnU4=
-k8s.io/apiserver v0.26.3/go.mod h1:CJe/VoQNcXdhm67EvaVjYXxR3QyfwpceKPuPaeLibTA=
 k8s.io/autoscaler/vertical-pod-autoscaler v0.9.0/go.mod h1:PwWTGRRCxefhAezrDbG/tRYSAW7etHjjMPAr8fXKVAA=
 k8s.io/autoscaler/vertical-pod-autoscaler v0.14.0 h1:HkQHkcuwVP3BgJpVqTGeYHro83qGBj8mWotygHZND1k=
 k8s.io/autoscaler/vertical-pod-autoscaler v0.14.0/go.mod h1:w6/LjLR3DPQd57vlgvgbpzpuJKsCiily0+OzQI+nyfI=

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -22,13 +22,12 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/golang/mock/gomock"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/admission/validator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/admission/validator"
 )
 
 var _ = Describe("SecretBinding validator", func() {

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -23,14 +23,14 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/admission"
+	apisonmetal "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal"
+	onmetalvalidation "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/admission"
-	apisonmetal "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal"
-	onmetalvalidation "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/validation"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type shoot struct {
@@ -40,21 +40,10 @@ type shoot struct {
 }
 
 // NewShootValidator returns a new instance of a shoot validator.
-func NewShootValidator() extensionswebhook.Validator {
-	return &shoot{}
-}
-
-// InjectScheme injects the given scheme into the validator.
-func (s *shoot) InjectScheme(scheme *runtime.Scheme) error {
-	s.decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
-	s.lenientDecoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
-	return nil
-}
-
-// InjectClient injects the given client into the validator.
-func (s *shoot) InjectClient(client client.Client) error {
-	s.client = client
-	return nil
+func NewShootValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &shoot{
+		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+	}
 }
 
 // Validate validates the given shoot objects.

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -45,7 +45,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:       "/webhooks/validate",
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(onmetal.Type)},
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator():         {{Obj: &core.Shoot{}}},
+			NewShootValidator(mgr):      {{Obj: &core.Shoot{}}},
 			NewSecretBindingValidator(): {{Obj: &core.SecretBinding{}}},
 		},
 	})

--- a/pkg/apis/onmetal/validation/controlplane_test.go
+++ b/pkg/apis/onmetal/validation/controlplane_test.go
@@ -51,7 +51,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
+					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("cloudControllerManager.featureGates.CustomResourceValidation"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -27,7 +27,6 @@ import (
 	extensionscloudproviderwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	extensioncontrolplanewebhook "github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
-
 	backupbucketcontroller "github.com/onmetal/gardener-extension-provider-onmetal/pkg/controller/backupbucket"
 	backupentrycontroller "github.com/onmetal/gardener-extension-provider-onmetal/pkg/controller/backupentry"
 	bastioncontroller "github.com/onmetal/gardener-extension-provider-onmetal/pkg/controller/bastion"

--- a/pkg/controller/backupbucket/add.go
+++ b/pkg/controller/backupbucket/add.go
@@ -15,13 +15,13 @@
 package backupbucket
 
 import (
+	"context"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
+	controllerconfig "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/config"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
-
-	controllerconfig "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/config"
 )
 
 var (
@@ -41,9 +41,9 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
-	return backupbucket.Add(mgr, backupbucket.AddArgs{
-		Actuator:          newActuator(&opts.BackupBucketConfig),
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
+	return backupbucket.Add(ctx, mgr, backupbucket.AddArgs{
+		Actuator:          newActuator(mgr, &opts.BackupBucketConfig),
 		ControllerOptions: opts.Controller,
 		Predicates:        backupbucket.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              onmetal.Type,
@@ -51,6 +51,6 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/controller/backupbucket/backupbucket.go
+++ b/pkg/controller/backupbucket/backupbucket.go
@@ -128,11 +128,11 @@ func (a *actuator) patchBackupBucketStatus(ctx context.Context, backupBucket *ex
 		Data: accessSecretData,
 	}
 
-	if err := controllerutil.SetOwnerReference(backupBucket, backupBucketSecret, a.Client().Scheme()); err != nil {
+	if err := controllerutil.SetOwnerReference(backupBucket, backupBucketSecret, a.client.Scheme()); err != nil {
 		return fmt.Errorf("failed to set owner reference for bucket generated secret %s: %w", client.ObjectKeyFromObject(backupBucketSecret), err)
 	}
 	//create backupbucket secret
-	if _, err := controllerutil.CreateOrPatch(ctx, a.Client(), backupBucketSecret, nil); err != nil {
+	if _, err := controllerutil.CreateOrPatch(ctx, a.client, backupBucketSecret, nil); err != nil {
 		return fmt.Errorf("failed to create backup bucket generated secret %s: %w", client.ObjectKeyFromObject(backupBucketSecret), err)
 	}
 
@@ -140,7 +140,7 @@ func (a *actuator) patchBackupBucketStatus(ctx context.Context, backupBucket *ex
 		Name:      backupBucketSecret.Name,
 		Namespace: backupBucketSecret.Namespace,
 	}
-	return a.Client().Status().Patch(ctx, backupBucket, patch)
+	return a.client.Status().Patch(ctx, backupBucket, patch)
 }
 
 // validateConfiguration checks whether a backup bucket configuration is valid.

--- a/pkg/controller/backupbucket/suite_test.go
+++ b/pkg/controller/backupbucket/suite_test.go
@@ -187,7 +187,7 @@ func SetupTest() *corev1.Namespace {
 		backupBucketConfig := controllerconfig.BackupBucketConfig{
 			BucketClassName: "my-bucket-class",
 		}
-		Expect(AddToManagerWithOptions(mgr, AddOptions{
+		Expect(AddToManagerWithOptions(ctx, mgr, AddOptions{
 			IgnoreOperationAnnotation: true,
 			BackupBucketConfig:        backupBucketConfig,
 		})).NotTo(HaveOccurred())

--- a/pkg/controller/backupentry/actuator.go
+++ b/pkg/controller/backupentry/actuator.go
@@ -24,19 +24,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type actuator struct {
 	client client.Client
 }
 
-func newActuator() genericactuator.BackupEntryDelegate {
-	return &actuator{}
-}
-
-func (a *actuator) InjectClient(client client.Client) error {
-	a.client = client
-	return nil
+func newActuator(mgr manager.Manager) genericactuator.BackupEntryDelegate {
+	return &actuator{
+		client: mgr.GetClient(),
+	}
 }
 
 func (a *actuator) GetETCDSecretData(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.BackupEntry, backupSecretData map[string][]byte) (map[string][]byte, error) {

--- a/pkg/controller/backupentry/actuator_test.go
+++ b/pkg/controller/backupentry/actuator_test.go
@@ -27,15 +27,13 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
-
-	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 )
 
 var _ = Describe("BackupEntry Delete", func() {
-	ns := SetupTest()
+	mgr, ns := SetupTest()
 
 	var (
 		ctrl               *gomock.Controller
@@ -45,10 +43,8 @@ var _ = Describe("BackupEntry Delete", func() {
 	)
 
 	BeforeEach(func(ctx SpecContext) {
-		a = newActuator()
+		a = newActuator(*mgr)
 		Expect(a).NotTo(BeNil())
-		err := a.(inject.Client).InjectClient(k8sClient)
-		Expect(err).NotTo(HaveOccurred())
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockS3ObjectLister = NewMocks3ObjectLister(ctrl)

--- a/pkg/controller/backupentry/add.go
+++ b/pkg/controller/backupentry/add.go
@@ -15,12 +15,13 @@
 package backupentry
 
 import (
+	"context"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 var (
@@ -38,9 +39,9 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
-	return backupentry.Add(mgr, backupentry.AddArgs{
-		Actuator:          genericactuator.NewActuator(newActuator()),
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
+	return backupentry.Add(ctx, mgr, backupentry.AddArgs{
+		Actuator:          genericactuator.NewActuator(mgr, newActuator(mgr)),
 		ControllerOptions: opts.Controller,
 		Predicates:        backupentry.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              onmetal.Type,
@@ -48,6 +49,6 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/controller/backupentry/suite_test.go
+++ b/pkg/controller/backupentry/suite_test.go
@@ -122,8 +122,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
-func SetupTest() *corev1.Namespace {
+func SetupTest() (*manager.Manager, *corev1.Namespace) {
 	namespace := &corev1.Namespace{}
+	var mgr manager.Manager
 
 	BeforeEach(func(ctx SpecContext) {
 		var mgrCtx context.Context
@@ -138,7 +139,8 @@ func SetupTest() *corev1.Namespace {
 		Expect(k8sClient.Create(ctx, namespace)).To(Succeed(), "failed to create test namespace")
 		DeferCleanup(k8sClient.Delete, namespace)
 
-		mgr, err := manager.New(cfg, manager.Options{
+		var err error
+		mgr, err = manager.New(cfg, manager.Options{
 			Scheme:             scheme.Scheme,
 			MetricsBindAddress: "0",
 		})
@@ -166,7 +168,7 @@ func SetupTest() *corev1.Namespace {
 		}
 		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
-		Expect(AddToManagerWithOptions(mgr, AddOptions{
+		Expect(AddToManagerWithOptions(ctx, mgr, AddOptions{
 			IgnoreOperationAnnotation: true,
 		})).NotTo(HaveOccurred())
 
@@ -176,5 +178,5 @@ func SetupTest() *corev1.Namespace {
 		}()
 	})
 
-	return namespace
+	return &mgr, namespace
 }

--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -16,19 +16,20 @@ package bastion
 
 import (
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
-	"github.com/gardener/gardener/extensions/pkg/controller/common"
-
 	controllerconfig "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type actuator struct {
-	common.RESTConfigContext
+	client        client.Client
 	bastionConfig *controllerconfig.BastionConfig
 }
 
 // NewActuator creates a new bastion.Actuator.
-func NewActuator(bastionConfig *controllerconfig.BastionConfig) bastion.Actuator {
+func NewActuator(mgr manager.Manager, bastionConfig *controllerconfig.BastionConfig) bastion.Actuator {
 	return &actuator{
+		client:        mgr.GetClient(),
 		bastionConfig: bastionConfig,
 	}
 }

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -31,7 +31,7 @@ import (
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensionsv1alpha1.Bastion, cluster *controller.Cluster) error {
 	log.V(2).Info("Deleting bastion host")
 
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), cluster.ObjectMeta.Name)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.client, cluster.ObjectMeta.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get onmetal client and namespace from cloudprovider secret: %w", err)
 	}

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -77,12 +77,12 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return fmt.Errorf("failed to determine options: %w", err)
 	}
 
-	infraStatus, err := getInfrastructureStatus(ctx, a.Client(), cluster)
+	infraStatus, err := getInfrastructureStatus(ctx, a.client, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get infrastructure status: %w", err)
 	}
 
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), cluster.ObjectMeta.Name)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.client, cluster.ObjectMeta.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get onmetal client and namespace from cloudprovider secret: %w", err)
 	}
@@ -115,7 +115,7 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, bastion *exte
 	log.V(2).Info("Reconciled bastion host")
 	patch := client.MergeFrom(bastion.DeepCopy())
 	bastion.Status.Ingress = endpoints.public
-	return a.Client().Status().Patch(ctx, bastion, patch)
+	return a.client.Status().Patch(ctx, bastion, patch)
 }
 
 // getMachineEndpoints function returns the bastion endpoints of a running

--- a/pkg/controller/bastion/add.go
+++ b/pkg/controller/bastion/add.go
@@ -15,13 +15,14 @@
 package bastion
 
 import (
+	"context"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
+	controllerconfig "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/config"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	controllerconfig "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/config"
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 var (
@@ -43,7 +44,7 @@ type AddOptions struct {
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return bastion.Add(mgr, bastion.AddArgs{
-		Actuator:          NewActuator(&opts.BastionConfig),
+		Actuator:          NewActuator(mgr, &opts.BastionConfig),
 		ConfigValidator:   NewConfigValidator(mgr.GetClient(), log.Log),
 		ControllerOptions: opts.Controller,
 		Predicates:        bastion.DefaultPredicates(opts.IgnoreOperationAnnotation),
@@ -52,6 +53,6 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 }
 
 // AddToManager adds a controller with the default AddOptions.
-func AddToManager(mgr manager.Manager) error {
+func AddToManager(_ context.Context, mgr manager.Manager) error {
 	return AddToManagerWithOptions(mgr, DefaultAddOptions)
 }

--- a/pkg/controller/bastion/configvalidator.go
+++ b/pkg/controller/bastion/configvalidator.go
@@ -20,7 +20,6 @@ import (
 	"net"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
-	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
@@ -35,7 +34,6 @@ import (
 
 // configValidator implements ConfigValidator for onmetal bastion resources.
 type configValidator struct {
-	common.ClientContext
 	client client.Client
 	logger logr.Logger
 }

--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -15,16 +15,17 @@
 package controlplane
 
 import (
+	"context"
+
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener/extensions/pkg/util"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/internal"
+	kubernetesclient "github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/internal/imagevector"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (
@@ -44,20 +45,26 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
-	return controlplane.Add(mgr, controlplane.AddArgs{
-		Actuator: genericactuator.NewActuator(onmetal.ProviderName,
-			secretConfigsFunc, shootAccessSecretsFunc, nil, nil,
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
+	gardenerClientset, err := kubernetesclient.NewWithConfig(kubernetesclient.WithRESTConfig(mgr.GetConfig()))
+	if err != nil {
+		return err
+	}
+
+	return controlplane.Add(ctx, mgr, controlplane.AddArgs{
+		Actuator: genericactuator.NewActuator(mgr, onmetal.ProviderName,
+			secretConfigsFunc, shootAccessSecretsFunc,
+			nil, nil,
 			configChart, controlPlaneChart, controlPlaneShootChart, nil, storageClassChart, nil,
-			NewValuesProvider(), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
-			imagevector.ImageVector(), internal.CloudProviderSecretName, nil, opts.WebhookServerNamespace, mgr.GetWebhookServer().Port),
+			NewValuesProvider(mgr), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
+			imagevector.ImageVector(), onmetal.CloudProviderConfigName, nil, opts.WebhookServerNamespace, mgr.GetWebhookServer().Port, gardenerClientset),
 		ControllerOptions: opts.Controller,
-		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Predicates:        controlplane.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
 		Type:              onmetal.Type,
 	})
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"context"
 	"time"
 
 	healthcheckconfig "github.com/gardener/gardener/extensions/pkg/apis/config"
@@ -52,8 +53,8 @@ var (
 )
 
 // RegisterHealthChecks registers health checks for each extension resource
-func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
-	if err := healthcheck.DefaultRegistration(
+func RegisterHealthChecks(ctx context.Context, mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
+	if err := healthcheck.DefaultRegistration(ctx,
 		onmetal.Type,
 		extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ControlPlaneResource),
 		func() client.ObjectList { return &extensionsv1alpha1.ControlPlaneList{} },
@@ -100,7 +101,7 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 		workerConditionTypesToRemove = workerConditionTypesToRemove.Delete(gardencorev1beta1.ShootControlPlaneHealthy)
 	}
 
-	return healthcheck.DefaultRegistration(
+	return healthcheck.DefaultRegistration(ctx,
 		onmetal.Type,
 		extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.WorkerResource),
 		func() client.ObjectList { return &extensionsv1alpha1.WorkerList{} },
@@ -114,6 +115,6 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager) error {
-	return RegisterHealthChecks(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return RegisterHealthChecks(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -15,15 +15,18 @@
 package infrastructure
 
 import (
-	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type actuator struct {
-	common.RESTConfigContext
+	client client.Client
 }
 
 // NewActuator creates a new infrastructure.Actuator.
-func NewActuator() infrastructure.Actuator {
-	return &actuator{}
+func NewActuator(mgr manager.Manager) infrastructure.Actuator {
+	return &actuator{
+		client: mgr.GetClient(),
+	}
 }

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -21,12 +21,11 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 // Delete implements infrastructure.Actuator.
@@ -34,7 +33,7 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 	log.V(2).Info("Deleting infrastructure")
 
 	// get onmetal credentials from infrastructure config
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), cluster.ObjectMeta.Name)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.client, cluster.ObjectMeta.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get onmetal client and namespace from cloudprovider secret: %w", err)
 	}

--- a/pkg/controller/infrastructure/actuator_delete_test.go
+++ b/pkg/controller/infrastructure/actuator_delete_test.go
@@ -18,6 +18,8 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -27,9 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 var _ = Describe("Infrastructure Reconcile", func() {

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -21,6 +21,10 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	api "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/helper"
+	apiv1alpha1 "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	"github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
@@ -30,11 +34,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	api "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal"
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/helper"
-	apiv1alpha1 "github.com/onmetal/gardener-extension-provider-onmetal/pkg/apis/onmetal/v1alpha1"
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 const (
@@ -55,7 +54,7 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, infra *extens
 	}
 
 	// get onmetal credentials from infrastructure config
-	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.Client(), cluster.ObjectMeta.Name)
+	onmetalClient, namespace, err := onmetal.GetOnmetalClientAndNamespaceFromCloudProviderSecret(ctx, a.client, cluster.ObjectMeta.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get onmetal client and namespace from cloudprovider secret: %w", err)
 	}
@@ -207,5 +206,5 @@ func (a *actuator) updateProviderStatus(
 	infra.Status.ProviderStatus = &runtime.RawExtension{
 		Object: infraStatus,
 	}
-	return a.Client().Status().Patch(ctx, infra, client.MergeFrom(infraBase))
+	return a.client.Status().Patch(ctx, infra, client.MergeFrom(infraBase))
 }

--- a/pkg/controller/infrastructure/add.go
+++ b/pkg/controller/infrastructure/add.go
@@ -15,12 +15,13 @@
 package infrastructure
 
 import (
+	"context"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 var (
@@ -38,17 +39,17 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given AddOptions to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
-	return infrastructure.Add(mgr, infrastructure.AddArgs{
-		Actuator:          NewActuator(),
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
+	return infrastructure.Add(ctx, mgr, infrastructure.AddArgs{
+		Actuator:          NewActuator(mgr),
 		ConfigValidator:   NewConfigValidator(mgr.GetClient(), log.Log),
 		ControllerOptions: opts.Controller,
-		Predicates:        infrastructure.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Predicates:        infrastructure.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
 		Type:              onmetal.Type,
 	})
 }
 
 // AddToManager adds a controller with the default AddOptions.
-func AddToManager(mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -33,7 +32,6 @@ import (
 
 // configValidator implements ConfigValidator for onmetal infrastructure resources.
 type configValidator struct {
-	common.ClientContext
 	client client.Client
 	logger logr.Logger
 }

--- a/pkg/controller/infrastructure/suite_test.go
+++ b/pkg/controller/infrastructure/suite_test.go
@@ -208,7 +208,7 @@ func SetupTest() *corev1.Namespace {
 		}
 		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
-		Expect(AddToManagerWithOptions(mgr, AddOptions{
+		Expect(AddToManagerWithOptions(mgrCtx, mgr, AddOptions{
 			IgnoreOperationAnnotation: true,
 		})).NotTo(HaveOccurred())
 

--- a/pkg/controller/worker/add.go
+++ b/pkg/controller/worker/add.go
@@ -15,14 +15,16 @@
 package worker
 
 import (
+	"context"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	machinescheme "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/scheme"
+	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 )
 
 var (
@@ -45,24 +47,29 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
-	scheme := mgr.GetScheme()
-	if err := apiextensionsscheme.AddToScheme(scheme); err != nil {
-		return err
-	}
-	if err := machinescheme.AddToScheme(scheme); err != nil {
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		apiextensionsscheme.AddToScheme,
+		machinescheme.AddToScheme,
+	)
+	if err := schemeBuilder.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 
-	return worker.Add(mgr, worker.AddArgs{
-		Actuator:          NewActuator(opts.GardenletManagesMCM),
+	actuator, err := NewActuator(mgr, opts.GardenletManagesMCM)
+	if err != nil {
+		return err
+	}
+
+	return worker.Add(ctx, mgr, worker.AddArgs{
+		Actuator:          actuator,
 		ControllerOptions: opts.Controller,
-		Predicates:        worker.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Predicates:        worker.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
 		Type:              onmetal.Type,
 	})
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -57,7 +57,7 @@ var (
 
 func (w *workerDelegate) GetMachineControllerManagerChartValues(ctx context.Context) (map[string]interface{}, error) {
 	namespace := &corev1.Namespace{}
-	if err := w.Client().Get(ctx, kutil.Key(w.worker.Namespace), namespace); err != nil {
+	if err := w.client.Get(ctx, kutil.Key(w.worker.Namespace), namespace); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -70,7 +70,7 @@ func (w *workerDelegate) findMachineImage(name, version string, architecture *st
 	// Try to look up machine image in worker provider status as it was not found in componentconfig.
 	if providerStatus := w.worker.Status.ProviderStatus; providerStatus != nil {
 		workerStatus := &apiv1alpha1.WorkerStatus{}
-		if _, _, err := w.Decoder().Decode(providerStatus.Raw, nil, workerStatus); err != nil {
+		if _, _, err := w.decoder.Decode(providerStatus.Raw, nil, workerStatus); err != nil {
 			return "", fmt.Errorf("could not decode worker status of worker '%s': %w", kutil.ObjectName(w.worker), err)
 		}
 
@@ -99,7 +99,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*apiv1alpha1.WorkerStatus
 		return workerStatus, nil
 	}
 
-	if _, _, err := w.Decoder().Decode(w.worker.Status.ProviderStatus.Raw, nil, workerStatus); err != nil {
+	if _, _, err := w.decoder.Decode(w.worker.Status.ProviderStatus.Raw, nil, workerStatus); err != nil {
 		return nil, fmt.Errorf("could not decode WorkerStatus '%s': %w", kutil.ObjectName(w.worker), err)
 	}
 
@@ -109,7 +109,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*apiv1alpha1.WorkerStatus
 func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerStatus *apiv1alpha1.WorkerStatus) error {
 	status := &apiv1alpha1.WorkerStatus{}
 
-	if err := w.Scheme().Convert(workerStatus, status, nil); err != nil {
+	if err := w.scheme.Convert(workerStatus, status, nil); err != nil {
 		return err
 	}
 
@@ -120,5 +120,5 @@ func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerS
 
 	patch := client.MergeFrom(w.worker.DeepCopy())
 	w.worker.Status.ProviderStatus = &runtime.RawExtension{Object: status}
-	return w.Client().Status().Patch(ctx, w.worker, patch)
+	return w.client.Status().Patch(ctx, w.worker, patch)
 }

--- a/pkg/controller/worker/machine_images_test.go
+++ b/pkg/controller/worker/machine_images_test.go
@@ -15,7 +15,6 @@
 package worker
 
 import (
-	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	commonv1alpha1 "github.com/onmetal/onmetal-api/api/common/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -51,7 +50,7 @@ var _ = Describe("MachinesImages", func() {
 
 		By("creating a worker delegate")
 		decoder := serializer.NewCodecFactory(k8sClient.Scheme(), serializer.EnableStrict).UniversalDecoder()
-		workerDelegate, err := NewWorkerDelegate(common.NewClientContext(k8sClient, k8sClient.Scheme(), decoder), "", w, cluster)
+		workerDelegate, err := NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, cluster)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("calling the updating machine image status")

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -59,12 +59,12 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 
 	// apply machine classes and machine secrets
 	for _, class := range machineClasses {
-		if _, err := controllerutil.CreateOrPatch(ctx, w.Client(), class, nil); err != nil {
+		if _, err := controllerutil.CreateOrPatch(ctx, w.client, class, nil); err != nil {
 			return fmt.Errorf("failed to create/patch machineclass %s: %w", client.ObjectKeyFromObject(class), err)
 		}
 	}
 	for _, secret := range machineClassSecrets {
-		if _, err := controllerutil.CreateOrPatch(ctx, w.Client(), secret, nil); err != nil {
+		if _, err := controllerutil.CreateOrPatch(ctx, w.client, secret, nil); err != nil {
 			return fmt.Errorf("failed to create/patch machineclass secret %s: %w", client.ObjectKeyFromObject(secret), err)
 		}
 	}
@@ -117,7 +117,7 @@ func (w *workerDelegate) generateMachineClassAndSecrets() ([]*machinecontrollerv
 	)
 
 	infrastructureStatus := &onmetalextensionv1alpha1.InfrastructureStatus{}
-	if _, _, err := w.Decoder().Decode(w.worker.Spec.InfrastructureProviderStatus.Raw, nil, infrastructureStatus); err != nil {
+	if _, _, err := w.decoder.Decode(w.worker.Spec.InfrastructureProviderStatus.Raw, nil, infrastructureStatus); err != nil {
 		return nil, nil, fmt.Errorf("failed to decode infra status: %w", err)
 	}
 

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -30,6 +30,6 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("adding webhook to manager")
 	return cloudprovider.New(mgr, cloudprovider.Args{
 		Provider: onmetal.Type,
-		Mutator:  cloudprovider.NewMutator(logger, NewEnsurer(logger)),
+		Mutator:  cloudprovider.NewMutator(mgr, logger, NewEnsurer(logger)),
 	})
 }

--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -47,7 +47,7 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
 			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
 		},
-		Mutator: genericmutator.NewMutator(NewEnsurer(logger, GardenletManagesMCM), oscutils.NewUnitSerializer(),
+		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger, GardenletManagesMCM), oscutils.NewUnitSerializer(),
 			kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
 	})
 }


### PR DESCRIPTION
# Proposed Changes

The package `controller-runtime/pkg/runtime/inject` has been removed in `controller-runtime` `v0.15`. This package contained long deprecated injection functions (like `InjectScheme`, `InjectLogger`, `InjectConfig`, `InjectClient`, `InjectCache`, etc.).

The runtime injection functionality has been deprecated since Controller Runtime v0.10; all of the above fields can be passed from the `Manager` to structs or interfaces that need them.