### PR TITLE
Fix potential `nil` pointer deref in `isOverlayEnabled`

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -425,7 +425,7 @@ func getCCMChartValues(
 }
 
 func isOverlayEnabled(networking *gardencorev1beta1.Networking) (bool, error) {
-	if networking == nil {
+	if networking == nil || networking.ProviderConfig == nil {
 		return false, nil
 	}
 


### PR DESCRIPTION
# Proposed Changes

- Add a check for `networking.ProviderConfig` in the `isOverlayEnabled` function
